### PR TITLE
Fix drop down menu main function

### DIFF
--- a/Assests/Images/Chevron.svg
+++ b/Assests/Images/Chevron.svg
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg width="14px" height="8px" viewBox="0 0 14 8" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
-    <!-- Generator: Sketch 59 (86127) - https://sketch.com -->
-    <title>Path 9</title>
+<svg width="41px" height="35px" viewBox="0 0 41 35" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
+    <title>chevron</title>
     <desc>Created with Sketch.</desc>
-    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">
-        <g id="Drop-down-choice" transform="translate(-145.000000, -24.000000)" stroke="#363636" stroke-width="2">
-            <polyline id="Path-9" points="146 25 152 31 158 25"></polyline>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Kommun" transform="translate(-327.000000, -8.000000)">
+            <g id="chevron">
+                <g transform="translate(327.000000, 8.000000)">
+                    <rect id="Rectangle" fill="#FFFFFF" x="1" y="0" width="40" height="35"></rect>
+                    <polyline id="Path-9" stroke="#363636" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="15 17 21 23 27 17"></polyline>
+                    <line x1="1" y1="0" x2="1" y2="35" id="Path-18" stroke="#363636"></line>
+                </g>
+            </g>
         </g>
     </g>
 </svg>

--- a/Assests/Images/chevron2.svg
+++ b/Assests/Images/chevron2.svg
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="58px" height="35px" viewBox="0 0 58 35" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 60.1 (88133) - https://sketch.com -->
+    <title>chevron2</title>
+    <desc>Created with Sketch.</desc>
+    <g id="Symbols" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Kommun" transform="translate(-314.000000, -8.000000)">
+            <g id="chevron2">
+                <g transform="translate(314.000000, 8.000000)">
+                    <rect id="Rectangle" fill="#FFFFFF" x="0" y="0" width="58" height="35"></rect>
+                    <polyline id="Path-9" stroke="#363636" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" points="24 17 30 23 36 17"></polyline>
+                    <line x1="1.5" y1="0" x2="1.5" y2="35" id="Path-18" stroke="#363636"></line>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/Index.html
+++ b/Index.html
@@ -96,7 +96,6 @@
                                 <p class="gridHeader">Kommun</p>
                                 <div class="dropdown">
                                     <button id='dropDownButton' class="dropbtn">Alla...</button>
-                                    <element><img src="./Assests/Images/chevron.svg" class="chevron">
                                     <element>
                                         <div id="kommun" class="dropdown-content">
                                             <a href="#gothenburg 'javascript:void();'" onclick="toggleActive('gothenburg')" id='gothenburg' class="dropdownText">Göteborg</a>
@@ -158,7 +157,6 @@
                                     <div class="rumB">
                                         <div class="dropdown2">
                                             <button onclick="myFunction3()" class="dropbtn2" id="minimum-room"></button>
-                                            <element><img src="./Assests/Images/chevron.svg" class="chevron"></element>
                                             <div id="myDropdown3" class="dropdown-content2">
                                                 <a href="#min1" class="dropdownText" onclick="getValue3(1)">1</a>
                                                 <a href="#min2" class="dropdownText" onclick="getValue3(2)">2</a>
@@ -173,7 +171,6 @@
                                         </div>
                                         <div class="dropdown2b">
                                             <button onclick="myFunction3b()" class="dropbtn2" id="maximum-room"></button>
-                                            <element><img src="./Assests/Images/chevron.svg" class="chevron"></element>
                                             <div id="myDropdown3b" class="dropdown-content2">
                                                 <a href="#max1" class="dropdownText" onclick="getValue4(1)">1</a>
                                                 <a href="#max2" class="dropdownText" onclick="getValue4(2)">2</a>
@@ -195,7 +192,6 @@
                                     <div class="hyraB">
                                             <div class="dropdown2">
                                                 <button onclick="myFunction2()" class="dropbtn2" id="minimum-rent">Min</button>
-                                                <element><img src="./Assests/Images/chevron.svg" class="chevron" onclick="myFunction2()"></element>
                                                     <div id="myDropdown2" class="dropdown-content2">
                                                         <a href="#min1000" class="dropdownText" onclick="getValue(1000)">1000</a>
                                                         <a href="#min2000" class="dropdownText" onclick="getValue(2000)">2000</a>
@@ -212,7 +208,6 @@
                                             </div>
                                             <div class="dropdown2b">
                                                 <button onclick="myFunction2b()" class="dropbtn2" id ="maximum-rent"></button>
-                                                <element><img src="./Assests/Images/chevron.svg" class="chevron"></element>
                                                     <div id="myDropdown2b" class="dropdown-content2">
                                                         <a href="#max1000" class="dropdownText" onclick="getValue2(1000)">1000</a>
                                                         <a href="#max2000" class="dropdownText" onclick="getValue2(2000)">2000</a>
@@ -234,7 +229,6 @@
                                         <div class="boareaB">
                                             <div class="dropdown2" id="original">
                                                 <button onclick="myFunction4()" class="dropbtn2" id="minimum-living-area"></button>
-                                                <element><img src="./Assests/Images/chevron.svg" class="chevron"></element>
                                                     <div id="myDropdown4" class="dropdown-content2">
                                                         <a href="#min20" class="dropdownText" onclick="getValue5(20)">20</a>
                                                         <a href="#min30" class="dropdownText" onclick="getValue5(30)">30</a>
@@ -255,7 +249,6 @@
                                             </div>
                                             <div class="dropdown2b">
                                                     <button onclick="myFunction4b()" class="dropbtn2" id="maximum-living-area"></button>
-                                                    <element><img src="./Assests/Images/chevron.svg" class="chevron"></element>
                                                         <div id="myDropdown4b" class="dropdown-content2">
                                                             <a href="#max20" class="dropdownText" onclick="getValue6(20)">20</a>
                                                             <a href="#max30" class="dropdownText" onclick="getValue6(30)">30</a>

--- a/Index.html
+++ b/Index.html
@@ -352,7 +352,6 @@
                         kommunDc.classList.remove("show");
                     }
                 }
-
             }
             
             window.onclick = function offClick2(event) {

--- a/stylesheets/aboveFold.css
+++ b/stylesheets/aboveFold.css
@@ -169,6 +169,10 @@
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+    background-image: url("../Assests/Images/chevron2.svg");
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: right;
 }
   
 .dropdown {
@@ -244,6 +248,10 @@
     color: #444444;
     text-align: justify;
     margin-right: 0px;
+    background-image: url("../Assests/Images/chevron2.svg");
+    background-repeat: no-repeat;
+    background-position-y: center;
+    background-position-x: right;
 }
 
   
@@ -476,6 +484,10 @@
         margin-top: 4px;
         font-size: 14px;
         text-align: left;
+        background-image: url("../Assests/Images/chevron.svg");
+        background-repeat: no-repeat;
+        background-position-y: center;
+        background-position-x: right;
     }
     
     .dropdown-content {
@@ -508,6 +520,10 @@
         width: 100%;
         margin-top: 4px;
         margin-right: 3px;
+        background-image: url("../Assests/Images/chevron.svg");
+        background-repeat: no-repeat;
+        background-position-y: center;
+        background-position-x: right;
     }
       
     .dropdown2 {

--- a/stylesheets/aboveFold.css
+++ b/stylesheets/aboveFold.css
@@ -173,6 +173,8 @@
     background-repeat: no-repeat;
     background-position-y: center;
     background-position-x: right;
+    max-width: 368px;
+    max-height: 50px;
 }
   
 .dropdown {

--- a/stylesheets/aboveFold.css
+++ b/stylesheets/aboveFold.css
@@ -30,6 +30,7 @@
     display: none;
 }
 
+
 .mainFunctionBox{
     background: #E01171;
     box-shadow: 0 1px 10px 1px rgba(0,0,0,0.15);
@@ -157,6 +158,7 @@
     padding-left: 22px;
     padding-top: 16px;
     padding-bottom: 16px;
+    padding-right: 60px;
     font-size: 14px;
     border: none;
     cursor: pointer;

--- a/stylesheets/aboveFold.css
+++ b/stylesheets/aboveFold.css
@@ -166,6 +166,9 @@
     color: #444444;
     text-align: justify;
     cursor:pointer;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 }
   
 .dropdown {


### PR DESCRIPTION
This branch focuses on fixing small changes on the dropdown menus in the main function box. What I've changed is:
- Added a different chevron design to match the sketch design
- Added css to text to hide the overflow
- Added padding to dropdown boxes to stop the text from overflowing
- Added a different chevron to the mobile version since the desktop version is too wide